### PR TITLE
Merge from Navigator to Dev - do away with 3rd party styling 

### DIFF
--- a/src/scipyen/gui/mainwindow.py
+++ b/src/scipyen/gui/mainwindow.py
@@ -108,25 +108,24 @@ except:
 # END About QStyle plugins
 
 # BEGIN pyqtdarktheme - recommended for Windows
-hasQDarkTheme = False
-try:
-    import qdarktheme
-    hasQDarkTheme = True
-except:
-    pass
+# hasQDarkTheme = False
+# try:
+#     import qdarktheme
+#     hasQDarkTheme = True
+# except:
+#     pass
 
 # END pyqtdarktheme
 
 # BEGIN qdarkstyle is another possibility (for windows)
 # based entirely on style sheets
-hasQDarkStyle = False
+# hasQDarkStyle = False
 
-try:
-    import qdarkstyle
-    hasQDarkStyle = True
-except:
-    hasQDarkStyle = False
-# if sys.platform.startswith("win32"):
+# try:
+#     import qdarkstyle
+#     hasQDarkStyle = True
+# except:
+#     hasQDarkStyle = False
 
 # END qdarkstyle
 
@@ -2037,18 +2036,25 @@ class ScipyenWindow(__QMainWindow__, __UI_MainWindow__, WorkspaceGuiMixin):
         # the case where PyQt5 was pulled from pypi or conda channel, vs having
         # been built locally?
         
+        # QtCore.QCoreApplication.instance().property("_qdarktheme_use_setup_style") is True:
+
+
         # themePaths = QtGui.QIcon.themeSearchPaths()
+        # WARNING: 2025-03-04 10:42:14
+        # does NOT report correctly when using qdarktheme!
         windowColor = QtWidgets.QApplication.palette().color(QtGui.QPalette.Window)
         _,_,v,_ = windowColor.getHsv()
-        if v > 128:
-            QtGui.QIcon.setThemeName("breeze")
-        else:
-            QtGui.QIcon.setThemeName("breeze-dark")
+        themeName="breeze" if v > 128 else "breeze-dark"
+        QtGui.QIcon.setThemeName(themeName)
+        # if v > 128:
+        #     QtGui.QIcon.setThemeName("breeze")
+        # else:
+        #     QtGui.QIcon.setThemeName("breeze-dark")
 
 
-        if sys.platform.startswith("win32"):
-            if hasQDarkTheme:
-                QtGui.QIcon.setThemeName("breeze-dark")
+        # if sys.platform.startswith("win32"):
+        #     if hasQDarkTheme:
+        #         QtGui.QIcon.setThemeName("breeze-dark")
 
     @property
     def scriptManagerAutoLaunch(self):
@@ -4845,12 +4851,12 @@ class ScipyenWindow(__QMainWindow__, __UI_MainWindow__, WorkspaceGuiMixin):
         # NOTE: 2023-03-29 14:08:58 CT - selecting bb10 bright & dark styles crashes the GUI - not sure why
         self._available_Qt_style_names_ = [
             s for s in QtWidgets.QStyleFactory.keys() if not s.startswith("bb10")]
-        if hasQDarkStyle:
-            self._available_Qt_style_names_.append("QDarkStyle Dark")
-            self._available_Qt_style_names_.append("QDarkStyle Light")
-            
-        if hasQDarkTheme:
-            self._available_Qt_style_names_.extend(f"Qt{v.capitalize()}" for v in qdarktheme.get_themes())
+#         if hasQDarkStyle:
+#             self._available_Qt_style_names_.append("QDarkStyle Dark")
+#             self._available_Qt_style_names_.append("QDarkStyle Light")
+#
+#         if hasQDarkTheme:
+#             self._available_Qt_style_names_.extend(f"Qt{v.capitalize()}" for v in qdarktheme.get_themes())
             
         # if sys.platform.startswith("win32") and hasQDarkStyle:
         #     self._available_Qt_style_names_.append("Dark Style")
@@ -7585,39 +7591,39 @@ class ScipyenWindow(__QMainWindow__, __UI_MainWindow__, WorkspaceGuiMixin):
             # self.app.setStyle(QtWidgets.QApplication.style())
             # self._current_GUI_style_name = "Default"
         else:
-            if hasQDarkTheme and val.startswith("Qt"):
-                #theme = val.replace("PyQtDarkTheme_", "")
-                theme = val.replace("Qt", "").lower()
-                qdarktheme.setup_theme(theme)
-            elif hasQDarkStyle and val.startswith("QDarkStyle"):
-                if val == "QDarkstyle Dark":
-                    self.app.setStyleSheet(qdarkstyle.load_stylesheet(palette = qdarkstyle.dark.palette.DarkPalette))
-                else:
-                    self.app.setStyleSheet(qdarkstyle.load_stylesheet(palette = qdarkstyle.light.palette.LightPalette))
-                    
-                styleProxy = MenuProxy(QtWidgets.QApplication.style())
-                self.app.setStyle(styleProxy)
-            else:
-                qtStyle = QtWidgets.QStyleFactory.create(val)
-                qtPalette = qtStyle.standardPalette()
-                styleProxy = MenuProxy(qtStyle)
-                
-                # NOTE: 2024-09-26 14:54:59 HACK 
-                # remove traces of qdarktheme from the app
-                # undoes the HACK in qdarktheme.setup_theme
-                qdarkstyleprop = "_qdarktheme_use_setup_style"
-                props = self.app.dynamicPropertyNames()
-                if qdarkstyleprop in (bytes(p).decode() for p in props):
-                    self.app.setProperty(qdarkstyleprop, False)
-                
-                self.app.setPalette(qtPalette)
-                self.app.setStyle(styleProxy)
-                
-                
-                
-                # NOTE: 2024-09-26 17:14:32
-                # quick hack to restore palette
-        
+            qtStyle = QtWidgets.QStyleFactory.create(val)
+            qtPalette = qtStyle.standardPalette()
+            styleProxy = MenuProxy(qtStyle)
+            self.app.setPalette(qtPalette)
+            self.app.setStyle(styleProxy)
+#             if hasQDarkTheme and val.startswith("Qt"):
+#                 #theme = val.replace("PyQtDarkTheme_", "")
+#                 theme = val.replace("Qt", "").lower()
+#                 qdarktheme.setup_theme(theme)
+#             elif hasQDarkStyle and val.startswith("QDarkStyle"):
+#                 if val == "QDarkstyle Dark":
+#                     self.app.setStyleSheet(qdarkstyle.load_stylesheet(palette = qdarkstyle.dark.palette.DarkPalette))
+#                 else:
+#                     self.app.setStyleSheet(qdarkstyle.load_stylesheet(palette = qdarkstyle.light.palette.LightPalette))
+#
+#                 styleProxy = MenuProxy(QtWidgets.QApplication.style())
+#                 self.app.setStyle(styleProxy)
+#             else:
+#                 qtStyle = QtWidgets.QStyleFactory.create(val)
+#                 qtPalette = qtStyle.standardPalette()
+#                 styleProxy = MenuProxy(qtStyle)
+#
+#                 # NOTE: 2024-09-26 14:54:59 HACK
+#                 # remove traces of qdarktheme from the app
+#                 # undoes the HACK in qdarktheme.setup_theme
+#                 qdarkstyleprop = "_qdarktheme_use_setup_style"
+#                 props = self.app.dynamicPropertyNames()
+#                 if qdarkstyleprop in (bytes(p).decode() for p in props):
+#                     self.app.setProperty(qdarkstyleprop, False)
+#
+                # self.app.setPalette(qtPalette)
+                # self.app.setStyle(styleProxy)
+
             
     @Slot()
     @safeWrapper

--- a/src/scipyen/iolib/navigation/navigator.py
+++ b/src/scipyen/iolib/navigation/navigator.py
@@ -1835,7 +1835,7 @@ class PlacesButton(UrlNavigatorButtonBase):
         lastIndex = min(nAvailableItems, maxIndex)
         
         for k, (key, val) in enumerate(actionsMap.items()):
-            if k == 0:
+            if k == 0:# and sys.platform.startswith("linux"):
                 action0 = QtWidgets.QAction("Places", menu)
                 action0.setSeparator(True)
                 menu.addAction(action0)

--- a/src/scipyen/scipyen.py
+++ b/src/scipyen/scipyen.py
@@ -207,12 +207,12 @@ from core.prog import scipywarn
 if os.environ["QT_API"] == "pyside2":
     scipywarn("PySide2 support is not fully implemented; expect trouble")
 
-hasQDarkTheme = False
-try:
-    import qdarktheme
-    hasQDarkTheme = True
-except:
-    pass
+# hasQDarkTheme = False
+# try:
+#     import qdarktheme
+#     hasQDarkTheme = True
+# except:
+#     pass
 
 
 # NOTE: 2023-09-28 22:12:25 
@@ -260,49 +260,60 @@ QtGui.QIcon.setFallbackSearchPaths(fbPaths)
 # On linux we rely on platform plugins (which also get bundled when
 # building a pyinstaller bundle, as per scipyen.spec)
 if sys.platform.startswith("win32"):
-    if hasQDarkTheme:
-        # qdarktheme.setup_theme("auto") # NOTE: 2025-03-02 20:52:51
-                                         # this MUST be called after the initlization of the QApplication
-                                         # see NOTE: 2025-03-02 20:53:09 below
-        qdarktheme.enable_hi_dpi()
-        QtGui.QIcon.setThemeName("breeze-dark")
-    else:
-        windowColor = QtWidgets.QApplication.palette().color(QtGui.QPalette.Window)
-        _,_,v,_ = windowColor.getHsv()
-        if v > 128:
-            QtGui.QIcon.setThemeName("breeze")
-        else:
-            QtGui.QIcon.setThemeName("breeze-dark")
-            
+    windowColor = QtWidgets.QApplication.palette().color(QtGui.QPalette.Window)
+    _,_,v,_ = windowColor.getHsv()
+    themeName="breeze" if v > 128 else "breeze-dark"
+    # print(f"windowColor HSV: {v} -> themeName: {themeName}")
+
+    QtGui.QIcon.setThemeName(themeName)
+    # if hasQDarkTheme:
+    #     # qdarktheme.setup_theme("auto") # NOTE: 2025-03-02 20:52:51
+    #                                      # this MUST be called after the initlization of the QApplication
+    #                                      # see NOTE: 2025-03-02 20:53:09 below
+    #     qdarktheme.enable_hi_dpi()
+    #     QtGui.QIcon.setThemeName("breeze-dark")
+    # else:
+    #     windowColor = QtWidgets.QApplication.palette().color(QtGui.QPalette.Window)
+    #     _,_,v,_ = windowColor.getHsv()
+    #     themeName="breeze" if v > 128 else "breeze-dark"
+    #     # print(f"windowColor HSV: {v} -> themeName: {themeName}")
+    #
+    #     QtGui.QIcon.setThemeName(themeName)
+
+        # if v > 128:
+        #     QtGui.QIcon.setThemeName("breeze")
+        # else:
+        #     QtGui.QIcon.setThemeName("breeze-dark")
+
         # FIXME 2023-09-28 23:22:31 BUG
-        # github merry-go-round replaces svg symbolic links (linux) with 
-        # simple text files containing the name of the target - this causes 
+        # github merry-go-round replaces svg symbolic links (linux) with
+        # simple text files containing the name of the target - this causes
         # the qt-svg plugin to sill out tons of error messages
         # TODO: either
         # 1) figure out how to ignore these symbolic links on Windows
         # 2) figure out how to ignore the qt-svg error messages
         #
-        # I prefer the first option; a contrived solution is to store on git hub
-        # an archive of the icon directories, and ignore the icons directories in 
+        # I would prefer the first option; a contrived solution is to store on git hub
+        # an archive of the icon directories, and ignore the icons directories in
         # .gitignore
         # unfortunately, this means that after each git pull we'd have to manually
-        # expand these directory, onse something has changed
+        # expand these directory, once something has changed
         #
         # 3) incorporate these icons in qrc and resources.py files
-        # the problem with that is that the py and qrc files sizes easily 
+        # the problem with that is that the py and qrc files sizes easily
         # get over the file size limit in github, unless I somehow break down
         # these into a qrc/py resource files for each subdirectory - brrr...
         #
         # until then, on Windows we will have to put up with the qt-svg messages
         # for now...
-        
+
 elif sys.platform.startswith("darwin"):
     windowColor = QtWidgets.QApplication.palette().color(QtGui.QPalette.Window)
     _,_,v,_ = windowColor.getHsv()
-    if v > 128:
-        QtGui.QIcon.setThemeName("breeze")
-    else:
-        QtGui.QIcon.setThemeName("breeze-dark")
+    themeName="breeze" if v > 128 else "breeze-dark"
+    # print(f"windowColor HSV: {v} -> themeName: {themeName}")
+
+    QtGui.QIcon.setThemeName(themeName)
     
         
 #### END 3rd party modules
@@ -368,22 +379,23 @@ def main():
         # NOTE: 2025-01-22 08:56:42
         # this needs to be here in prder ot initialize navigator widgets
         import gui.mainwindow as mainwindow
-        
-            
-        if sys.platform.startswith("win32"):
-            # pass
-            if hasQDarkTheme:
-                qdarktheme.setup_theme("auto") # NOTE: 2025-03-02 20:53:09
-                                               # now, this can be called
-                
-        elif sys.platform.startswith("linux"):
-            # NOTE: 2024-05-04 10:16:33
-            # reuired on Wayland so that the window manager decorates the windows
-            # with the appropriate icon instead of using the generic Wayland one.
-            # NOTE that this good to have even when forcing the use xcb platform 
-            # (see NOTE: 2024-05-04 10:14:08 above) as it conforms to the desktop
-            # standards
-            app.setDesktopFileName("Scipyen")
+
+        app.setDesktopFileName("Scipyen")
+
+#         if sys.platform.startswith("win32"):
+#             # pass
+#             if hasQDarkTheme:
+#                 qdarktheme.setup_theme("auto") # NOTE: 2025-03-02 20:53:09
+#                                                # now, this can be called
+#
+#         elif sys.platform.startswith("linux"):
+#             # NOTE: 2024-05-04 10:16:33
+#             # reuired on Wayland so that the window manager decorates the windows
+#             # with the appropriate icon instead of using the generic Wayland one.
+#             # NOTE that this good to have even when forcing the use xcb platform
+#             # (see NOTE: 2024-05-04 10:14:08 above) as it conforms to the desktop
+#             # standards
+#             app.setDesktopFileName("Scipyen")
 
 
         # NOTE: 2023-01-08 00:48:47


### PR DESCRIPTION
Doing away with 3rd party styling packages (e.g. qdarktheme or qdarkstyle) because the increased complexity of GUI code in Scipyen (especially in navigator).

This has no consequences when Scipyen is running a PyQt5 built from sources, on the machine it is run.
